### PR TITLE
transitioning to modules by first fixing this path, then removing forked

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/gorilla/mux
+module github.com/kiip/mux


### PR DESCRIPTION
mux altogether, then pointing back at mainline gorilla, then pinning
versions